### PR TITLE
Bump version to 1.0.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `flex_columns` Changelog
 
+## 1.0.10, 2022-04-11
+
+* Bump gem version to resolve conflicts with original gem version
+
 ## 1.0.9, 2022-03-31
 
 * Bumped version of bundler and Activerecord to make the gem compatible with Rails 5

--- a/lib/flex_columns/version.rb
+++ b/lib/flex_columns/version.rb
@@ -1,4 +1,4 @@
 module FlexColumns
   # The current version of FlexColumns.
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end


### PR DESCRIPTION
### Description
In order to resolve conflicts with the original gem, it's required to bump the version to `1.0.10`.

This PR is dedicated to bumping the gem version to `1.0.10`