### PR TITLE
Bump activerecord to 6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 1.0.10, 2022-04-11
 
+* Bump ActiveRecord version to be compatible with Rails 6
+
+## 1.0.10, 2022-04-11
+
 * Bump gem version to resolve conflicts with original gem version
 
 ## 1.0.9, 2022-03-31

--- a/flex_columns.gemspec
+++ b/flex_columns.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   ar_version = ar_version.strip if ar_version
 
   version_spec = case ar_version
-  when nil then [ ">= 3.0", "<= 5.99.99" ]
+  when nil then [ ">= 3.0", "< 7" ]
   when 'master' then nil
   else [ "=#{ar_version}" ]
   end
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
     s.add_dependency("activerecord", *version_spec)
   end
 
-  s.add_dependency "activesupport", ">= 3.0", "<= 5.99.99"
+  s.add_dependency "activesupport", ">= 3.0", "< 7"
 
   # i18n released an 0.7.0 that's incompatible with Ruby 1.8.
   if RUBY_VERSION =~ /^1\.8\./

--- a/lib/flex_columns/version.rb
+++ b/lib/flex_columns/version.rb
@@ -1,4 +1,4 @@
 module FlexColumns
   # The current version of FlexColumns.
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/spec/flex_columns/system/bulk_system_spec.rb
+++ b/spec/flex_columns/system/bulk_system_spec.rb
@@ -130,7 +130,7 @@ describe "FlexColumns bulk operations" do
 
       object.bbb = "cannot-validate"
       object.valid?.should_not be
-      object.errors.keys.should == [ :bbb ]
+      object.errors.attribute_names.should == [ :bbb ]
       object.errors[:bbb].length.should == 1
       object.errors[:bbb][0].should match(/is not a number/i)
     end
@@ -145,7 +145,7 @@ describe "FlexColumns bulk operations" do
 
       object.bbb = "cannot-validate"
       object.valid?.should_not be
-      object.errors.keys.should == [ :bbb ]
+      object.errors.attribute_names.should == [ :bbb ]
       object.errors[:bbb].length.should == 1
       object.errors[:bbb][0].should match(/is not a number/i)
     end

--- a/spec/flex_columns/system/json_alias_system_spec.rb
+++ b/spec/flex_columns/system/json_alias_system_spec.rb
@@ -57,10 +57,10 @@ describe "FlexColumns JSON aliasing" do
     user.wants_email = -123
 
     user.valid?.should_not be
-    user.errors.keys.should == [ :'user_attributes.wants_email' ]
+    user.errors.attribute_names.should == [ :'user_attributes.wants_email' ]
 
     user.user_attributes.valid?.should_not be
-    user.user_attributes.errors.keys.should == [ :wants_email ]
+    user.user_attributes.errors.attribute_names.should == [ :wants_email ]
   end
 
   it "should prohibit conflicting JSON names" do

--- a/spec/flex_columns/system/types_system_spec.rb
+++ b/spec/flex_columns/system/types_system_spec.rb
@@ -25,7 +25,7 @@ describe "FlexColumns basic operations" do
     object.valid?.should_not be
 
     full_name = "user_attributes.#{field}".to_sym
-    object.errors.keys.should == [ full_name ]
+    object.errors.attribute_names.should == [ full_name ]
 
     if pattern
       object.errors[full_name].length.should == 1

--- a/spec/flex_columns/system/validations_system_spec.rb
+++ b/spec/flex_columns/system/validations_system_spec.rb
@@ -33,7 +33,7 @@ describe "FlexColumns validations" do
     e = capture_exception(::ActiveRecord::RecordInvalid) { user.save! }
 
     e.record.should be(user)
-    e.record.errors.keys.should == [ :'user_attributes.wants_email' ]
+    e.record.errors.attribute_names.should == [ :'user_attributes.wants_email' ]
     messages = e.record.errors[:'user_attributes.wants_email']
     messages.length.should == 1
 
@@ -56,7 +56,7 @@ describe "FlexColumns validations" do
     e = capture_exception(::ActiveRecord::RecordInvalid) { user.save! }
 
     e.record.should be(user)
-    e.record.errors.keys.should == [ :wants_email ]
+    e.record.errors.attribute_names.should == [ :wants_email ]
     messages = e.record.errors[:wants_email]
     messages.length.should == 1
 
@@ -82,7 +82,7 @@ describe "FlexColumns validations" do
     e = capture_exception(::ActiveRecord::RecordInvalid) { user.save! }
 
     e.record.should be(user)
-    e.record.errors.keys.should == [ :wants_email ]
+    e.record.errors.attribute_names.should == [ :wants_email ]
     messages = e.record.errors[:wants_email]
     messages.length.should == 1
 
@@ -96,7 +96,7 @@ describe "FlexColumns validations" do
     e = capture_exception(::ActiveRecord::RecordInvalid) { user.save! }
 
     e.record.should be(user)
-    e.record.errors.keys.should == [ :'user_attributes.wants_email' ]
+    e.record.errors.attribute_names.should == [ :'user_attributes.wants_email' ]
     messages = e.record.errors[:'user_attributes.wants_email']
     messages.length.should == 1
 

--- a/spec/flex_columns/unit/contents/column_data_spec.rb
+++ b/spec/flex_columns/unit/contents/column_data_spec.rb
@@ -7,7 +7,7 @@ describe FlexColumns::Contents::ColumnData do
   before :each do
     @field_set = double("field_set")
     allow(@field_set).to receive(:kind_of?).with(FlexColumns::Definition::FieldSet).and_return(true)
-    allow(@field_set).to receive(:all_field_names).with().and_return([ :foo, :bar, :baz ])
+    allow(@field_set).to receive(:all_field_names).with(no_args).and_return([ :foo, :bar, :baz ])
 
     @field_foo = double("field_foo")
     allow(@field_foo).to receive(:field_name).and_return(:foo)
@@ -38,7 +38,7 @@ describe FlexColumns::Contents::ColumnData do
     end
 
     @data_source = double("data_source")
-    allow(@data_source).to receive(:describe_flex_column_data_source).with().and_return("describedescribe")
+    allow(@data_source).to receive(:describe_flex_column_data_source).with(no_args).and_return("describedescribe")
     allow(@data_source).to receive(:notification_hash_for_flex_column_data_source).and_return(:notif1 => :a, :notif2 => :b)
 
     @json_string = '  {"bar":123,"foo":"bar","baz":"quux"}   '
@@ -302,7 +302,7 @@ describe FlexColumns::Contents::ColumnData do
         bad_encoding = double("bad_encoding")
         allow(bad_encoding).to receive(:kind_of?).with(String).and_return(true)
         allow(bad_encoding).to receive(:kind_of?).with(Hash).and_return(false)
-        expect(bad_encoding).to receive(:valid_encoding?).with().and_return(false)
+        expect(bad_encoding).to receive(:valid_encoding?).with(no_args).and_return(false)
 
         exception = StandardError.new("bonk")
         expect(FlexColumns::Errors::IncorrectlyEncodedStringInDatabaseError).to receive(:new).once.with(@data_source, bad_encoding).and_return(exception)
@@ -497,7 +497,7 @@ describe FlexColumns::Contents::ColumnData do
       it "should not allow unknown data to conflict with known data" do
         field_set = double("field_set")
         allow(field_set).to receive(:kind_of?).with(FlexColumns::Definition::FieldSet).and_return(true)
-        allow(field_set).to receive(:all_field_names).with().and_return([ :foo ])
+        allow(field_set).to receive(:all_field_names).with(no_args).and_return([ :foo ])
 
         field_foo = double("field_foo")
         allow(field_foo).to receive(:field_name).and_return(:foo)
@@ -519,7 +519,7 @@ describe FlexColumns::Contents::ColumnData do
 
         json_string = { :foo => 'aaa', :bar => 'bbb' }.to_json
         instance = klass.new(field_set, :storage_string => json_string, :data_source => @data_source,
-          :unknown_fields => :preserve, :storage => :text, :storage_string => json_string, :binary_header => true,
+          :unknown_fields => :preserve, :storage => :text, :binary_header => true,
           :null => true)
 
         instance[:foo].should == 'bbb'

--- a/spec/flex_columns/unit/contents/flex_column_contents_base_spec.rb
+++ b/spec/flex_columns/unit/contents/flex_column_contents_base_spec.rb
@@ -20,8 +20,8 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
   context "with a set-up class" do
     before :each do
       @model_class = Class.new
-      allow(@klass).to receive(:model_class).with().and_return(@model_class)
-      allow(@klass).to receive(:column_name).with().and_return(:fcn)
+      allow(@klass).to receive(:model_class).with(no_args).and_return(@model_class)
+      allow(@klass).to receive(:column_name).with(no_args).and_return(:fcn)
 
       @json_string = '{"foo":"bar","bar":"baz"}'
 
@@ -81,8 +81,8 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
         expect_column_data_creation(@json_string)
         @instance = @klass.new(@model_instance)
 
-        allow(@model_class).to receive(:name).with().and_return("mcname")
-        allow(@model_instance).to receive(:id).with().and_return("mcid")
+        allow(@model_class).to receive(:name).with(no_args).and_return("mcname")
+        allow(@model_instance).to receive(:id).with(no_args).and_return("mcid")
         s = @instance.describe_flex_column_data_source
 
         s.should match(/mcname/)
@@ -94,7 +94,7 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
         expect_column_data_creation(@json_string)
         @instance = @klass.new(@json_string)
 
-        allow(@model_class).to receive(:name).with().and_return("mcname")
+        allow(@model_class).to receive(:name).with(no_args).and_return("mcname")
         s = @instance.describe_flex_column_data_source
         s.should match(/mcname/)
         s.should match(/fcn/)
@@ -136,7 +136,7 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
         expect_column_data_creation(@json_string)
         @instance = @klass.new(@model_instance)
 
-        expect(@instance).to receive(:valid?).once.with().and_return(true)
+        expect(@instance).to receive(:valid?).once.with(no_args).and_return(true)
         @instance.before_validation!
       end
 
@@ -144,8 +144,11 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
         expect_column_data_creation(@json_string)
         @instance = @klass.new(@model_instance)
 
-        expect(@instance).to receive(:valid?).once.with().and_return(false)
-        allow(@instance).to receive(:errors).with().and_return({ :e1 => :m1, :e2 => :m2 })
+        expect(@instance).to receive(:valid?).once.with(no_args).and_return(false)
+        allow(@instance).to receive(:errors).with(no_args).and_return([
+          double('error', attribute: :e1, message: :m1),
+          double('error', attribute: :e2, message: :m2)
+        ])
 
         errors = Object.new
         class << errors
@@ -159,7 +162,7 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
           end
         end
 
-        allow(@model_instance).to receive(:errors).with().and_return(errors)
+        allow(@model_instance).to receive(:errors).with(no_args).and_return(errors)
 
         @instance.before_validation!
         all_errors = errors.all_errors
@@ -200,15 +203,15 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
         end
 
         it "should tell you if it's been deserialized" do
-          expect(@column_data).to receive(:deserialized?).once.with().and_return(true)
+          expect(@column_data).to receive(:deserialized?).once.with(no_args).and_return(true)
           @instance.deserialized?.should be
-          expect(@column_data).to receive(:deserialized?).once.with().and_return(false)
+          expect(@column_data).to receive(:deserialized?).once.with(no_args).and_return(false)
           @instance.deserialized?.should_not be
         end
 
         it "should save if the class tells it to" do
           expect(@klass).to receive(:requires_serialization_on_save?).once.with(@model_instance).and_return(true)
-          expect(@column_data).to receive(:to_stored_data).once.with().and_return("somestoreddata")
+          expect(@column_data).to receive(:to_stored_data).once.with(no_args).and_return("somestoreddata")
           expect(@model_instance).to receive(:[]=).once.with(:fcn, "somestoreddata")
           @instance.before_save!
         end
@@ -260,22 +263,22 @@ describe FlexColumns::Contents::FlexColumnContentsBase do
       end
 
       it "should delegate to the column data on #touch!" do
-        expect(@column_data).to receive(:touch!).once.with()
+        expect(@column_data).to receive(:touch!).once.with(no_args)
         @instance.touch!
       end
 
       it "should delegate to the column data on #to_json" do
-        expect(@column_data).to receive(:to_json).once.with().and_return("somejsondata")
+        expect(@column_data).to receive(:to_json).once.with(no_args).and_return("somejsondata")
         @instance.to_json.should == "somejsondata"
       end
 
       it "should delegate to the column data on #to_stored_data" do
-        expect(@column_data).to receive(:to_stored_data).once.with().and_return("somestoreddata")
+        expect(@column_data).to receive(:to_stored_data).once.with(no_args).and_return("somestoreddata")
         @instance.to_stored_data.should == "somestoreddata"
       end
 
       it "should delegate to the column data on #keys" do
-        expect(@column_data).to receive(:keys).once.with().and_return([ :a, :z, :q ])
+        expect(@column_data).to receive(:keys).once.with(no_args).and_return([ :a, :z, :q ])
         @instance.keys.should == [ :a, :z, :q ]
       end
     end

--- a/spec/flex_columns/unit/definition/field_definition_spec.rb
+++ b/spec/flex_columns/unit/definition/field_definition_spec.rb
@@ -17,7 +17,7 @@ describe FlexColumns::Definition::FieldDefinition do
 
   before :each do
     @flex_column_class = double("flex_column_class")
-    allow(@flex_column_class).to receive(:is_flex_column_class?).with().and_return(true)
+    allow(@flex_column_class).to receive(:is_flex_column_class?).with(no_args).and_return(true)
   end
 
   describe "#initialize" do
@@ -26,7 +26,7 @@ describe FlexColumns::Definition::FieldDefinition do
       lambda { klass.new(non_fcc, :foo, [ ], { }) }.should raise_error(ArgumentError)
 
       non_fcc = double("flex_column_class")
-      allow(non_fcc).to receive(:is_flex_column_class?).with().and_return(false)
+      allow(non_fcc).to receive(:is_flex_column_class?).with(no_args).and_return(false)
       lambda { klass.new(non_fcc, :foo, [ ], { }) }.should raise_error(ArgumentError)
 
       lambda { klass.new(@flex_column_class, :foo, [ ], { :foo => :bar }) }.should raise_error(ArgumentError)
@@ -96,7 +96,7 @@ describe FlexColumns::Definition::FieldDefinition do
         record = double("record")
         errors = double("errors")
 
-        allow(record).to receive(:errors).with().and_return(errors)
+        allow(record).to receive(:errors).with(no_args).and_return(errors)
 
         if expected_error
           expect(errors).to receive(:add).once.with(:foo, expected_error)
@@ -169,7 +169,7 @@ describe FlexColumns::Definition::FieldDefinition do
     end
 
     it "should define methods on the flex-column class" do
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(false)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(false)
       klass.new(@flex_column_class, :foo, [ ], { :json => :bar }).add_methods_to_flex_column_class!(@dmm)
 
       instance = @dmm.new(:foo => 123)
@@ -179,7 +179,7 @@ describe FlexColumns::Definition::FieldDefinition do
     end
 
     it "should define methods on the flex-column class privately if the flex-column says to" do
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(true)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(true)
       klass.new(@flex_column_class, :foo, [ ], { :json => :bar }).add_methods_to_flex_column_class!(@dmm)
 
       instance = @dmm.new(:foo => 123)
@@ -193,7 +193,7 @@ describe FlexColumns::Definition::FieldDefinition do
     end
 
     it "should define methods on the flex-column class privately if the field says to" do
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(false)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(false)
       klass.new(@flex_column_class, :foo, [ ], { :json => :bar, :visibility => :private }).add_methods_to_flex_column_class!(@dmm)
 
       instance = @dmm.new(:foo => 123)
@@ -207,7 +207,7 @@ describe FlexColumns::Definition::FieldDefinition do
     end
 
     it "should define methods on the flex-column class publicly if the field says to" do
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(true)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(true)
       klass.new(@flex_column_class, :foo, [ ], { :json => :bar, :visibility => :public }).add_methods_to_flex_column_class!(@dmm)
 
       instance = @dmm.new(:foo => 123)
@@ -238,12 +238,12 @@ describe FlexColumns::Definition::FieldDefinition do
 
       flex_instance = { }
       field = klass.new(@flex_column_class, :foo, [ ], create_options)
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(fields_are_private_by_default)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(fields_are_private_by_default)
 
       allow(@model_class).to receive(:_flex_columns_safe_to_define_method?).with(method_name.to_sym).and_return(safe_to_define)
       allow(@model_class).to receive(:_flex_columns_safe_to_define_method?).with("#{method_name}=".to_sym).and_return(safe_to_define)
-      allow(@flex_column_class).to receive(:delegation_type).with().and_return(delegation_type)
-      allow(@flex_column_class).to receive(:delegation_prefix).with().and_return(delegation_prefix)
+      allow(@flex_column_class).to receive(:delegation_type).with(no_args).and_return(delegation_type)
+      allow(@flex_column_class).to receive(:delegation_prefix).with(no_args).and_return(delegation_prefix)
 
       field.add_methods_to_model_class!(@dmm, @model_class)
 
@@ -378,14 +378,14 @@ describe FlexColumns::Definition::FieldDefinition do
       method_should_exist = options[:method_should_exist]
       should_be_private = options[:should_be_private]
 
-      allow(@flex_column_class).to receive(:delegation_type).with().and_return(delegation_type)
-      allow(@flex_column_class).to receive(:delegation_prefix).with().and_return(delegation_prefix)
-      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with().and_return(fields_are_private_by_default)
+      allow(@flex_column_class).to receive(:delegation_type).with(no_args).and_return(delegation_type)
+      allow(@flex_column_class).to receive(:delegation_prefix).with(no_args).and_return(delegation_prefix)
+      allow(@flex_column_class).to receive(:fields_are_private_by_default?).with(no_args).and_return(fields_are_private_by_default)
 
       @model_class = double("model_class")
-      allow(@model_class).to receive(:name).with().and_return("mcname")
-      allow(@flex_column_class).to receive(:model_class).with().and_return(@model_class)
-      allow(@flex_column_class).to receive(:column_name).with().and_return(:colname)
+      allow(@model_class).to receive(:name).with(no_args).and_return("mcname")
+      allow(@flex_column_class).to receive(:model_class).with(no_args).and_return(@model_class)
+      allow(@flex_column_class).to receive(:column_name).with(no_args).and_return(:colname)
 
       target_class = double("target_class")
       allow(target_class).to receive(:_flex_columns_safe_to_define_method?).with(method_name.to_sym).and_return(safe_to_define)

--- a/spec/flex_columns/unit/definition/field_set_spec.rb
+++ b/spec/flex_columns/unit/definition/field_set_spec.rb
@@ -10,21 +10,21 @@ describe FlexColumns::Definition::FieldSet do
 
   before :each do
     @model_class = double("model_class")
-    allow(@model_class).to receive(:name).with().and_return("modname")
+    allow(@model_class).to receive(:name).with(no_args).and_return("modname")
 
     @flex_column_class = double("flex_column_class")
-    allow(@flex_column_class).to receive(:model_class).with().and_return(@model_class)
-    allow(@flex_column_class).to receive(:column_name).with().and_return("colname")
+    allow(@flex_column_class).to receive(:model_class).with(no_args).and_return(@model_class)
+    allow(@flex_column_class).to receive(:column_name).with(no_args).and_return("colname")
 
     @instance = klass.new(@flex_column_class)
   end
 
   it "should allow defining fields and returning them" do
     @field_foo = double("field_foo")
-    allow(@field_foo).to receive(:json_storage_name).with().and_return(:foo_storage)
+    allow(@field_foo).to receive(:json_storage_name).with(no_args).and_return(:foo_storage)
 
     @field_bar = double("field_bar")
-    allow(@field_bar).to receive(:json_storage_name).with().and_return(:storage_bar)
+    allow(@field_bar).to receive(:json_storage_name).with(no_args).and_return(:storage_bar)
 
     expect(FlexColumns::Definition::FieldDefinition).to receive(:new).once.with(@flex_column_class, :foo, [ ], { }).and_return(@field_foo)
     @instance.field(' fOo ')
@@ -51,12 +51,12 @@ describe FlexColumns::Definition::FieldSet do
 
   it "should raise if there's a duplicate JSON storage name" do
     @field_foo = double("field_foo")
-    allow(@field_foo).to receive(:json_storage_name).with().and_return(:foo_storage)
-    allow(@field_foo).to receive(:field_name).with().and_return(:foo)
+    allow(@field_foo).to receive(:json_storage_name).with(no_args).and_return(:foo_storage)
+    allow(@field_foo).to receive(:field_name).with(no_args).and_return(:foo)
 
     @field_bar = double("field_bar")
-    allow(@field_bar).to receive(:json_storage_name).with().and_return(:foo_storage)
-    allow(@field_bar).to receive(:field_name).with().and_return(:bar)
+    allow(@field_bar).to receive(:json_storage_name).with(no_args).and_return(:foo_storage)
+    allow(@field_bar).to receive(:field_name).with(no_args).and_return(:bar)
 
     expect(FlexColumns::Definition::FieldDefinition).to receive(:new).once.with(@flex_column_class, :foo, [ ], { }).and_return(@field_foo)
     @instance.field(' fOo ')
@@ -76,12 +76,12 @@ describe FlexColumns::Definition::FieldSet do
 
   it "should allow redefining the same field, and the new field should win" do
     @field_foo_1 = double("field_foo_1")
-    allow(@field_foo_1).to receive(:json_storage_name).with().and_return(:foo_storage)
-    allow(@field_foo_1).to receive(:field_name).with().and_return(:foo)
+    allow(@field_foo_1).to receive(:json_storage_name).with(no_args).and_return(:foo_storage)
+    allow(@field_foo_1).to receive(:field_name).with(no_args).and_return(:foo)
 
     @field_foo_2 = double("field_foo_2")
-    allow(@field_foo_2).to receive(:json_storage_name).with().and_return(:foo_storage)
-    allow(@field_foo_2).to receive(:field_name).with().and_return(:foo)
+    allow(@field_foo_2).to receive(:json_storage_name).with(no_args).and_return(:foo_storage)
+    allow(@field_foo_2).to receive(:field_name).with(no_args).and_return(:foo)
 
     expect(FlexColumns::Definition::FieldDefinition).to receive(:new).once.with(@flex_column_class, :foo, [ ], { }).and_return(@field_foo_1)
     @instance.field(' fOo ')
@@ -95,10 +95,10 @@ describe FlexColumns::Definition::FieldSet do
 
   it "should call through to the fields on #add_delegated_methods!" do
     @field_foo = double("field_foo")
-    allow(@field_foo).to receive(:json_storage_name).with().and_return(:foo)
+    allow(@field_foo).to receive(:json_storage_name).with(no_args).and_return(:foo)
 
     @field_bar = double("field_bar")
-    allow(@field_bar).to receive(:json_storage_name).with().and_return(:bar)
+    allow(@field_bar).to receive(:json_storage_name).with(no_args).and_return(:bar)
 
     expect(FlexColumns::Definition::FieldDefinition).to receive(:new).once.with(@flex_column_class, :foo, [ ], { }).and_return(@field_foo)
     @instance.field(:foo)
@@ -119,10 +119,10 @@ describe FlexColumns::Definition::FieldSet do
 
   it "should call through to the fields on #include_fields_into!" do
     @field_foo = double("field_foo")
-    allow(@field_foo).to receive(:json_storage_name).with().and_return(:foo)
+    allow(@field_foo).to receive(:json_storage_name).with(no_args).and_return(:foo)
 
     @field_bar = double("field_bar")
-    allow(@field_bar).to receive(:json_storage_name).with().and_return(:bar)
+    allow(@field_bar).to receive(:json_storage_name).with(no_args).and_return(:bar)
 
     expect(FlexColumns::Definition::FieldDefinition).to receive(:new).once.with(@flex_column_class, :foo, [ ], { }).and_return(@field_foo)
     @instance.field(:foo)

--- a/spec/flex_columns/unit/definition/flex_column_contents_class_spec.rb
+++ b/spec/flex_columns/unit/definition/flex_column_contents_class_spec.rb
@@ -10,48 +10,48 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
     @klass.send(:extend, FlexColumns::Definition::FlexColumnContentsClass)
 
     @model_class = double("model_class")
-    allow(@model_class).to receive(:table_exists?).with().and_return(true)
+    allow(@model_class).to receive(:table_exists?).with(no_args).and_return(true)
     allow(@model_class).to receive(:kind_of?).with(Class).and_return(true)
-    allow(@model_class).to receive(:has_any_flex_columns?).with().and_return(true)
-    allow(@model_class).to receive(:name).with().and_return(:mcname)
+    allow(@model_class).to receive(:has_any_flex_columns?).with(no_args).and_return(true)
+    allow(@model_class).to receive(:name).with(no_args).and_return(:mcname)
 
     @column_foo = double("column_foo")
-    allow(@column_foo).to receive(:name).with().and_return(:foo)
-    allow(@column_foo).to receive(:type).with().and_return(:text)
-    allow(@column_foo).to receive(:text?).with().and_return(true)
-    allow(@column_foo).to receive(:null).with().and_return(true)
-    allow(@column_foo).to receive(:sql_type).with().and_return('clob')
+    allow(@column_foo).to receive(:name).with(no_args).and_return(:foo)
+    allow(@column_foo).to receive(:type).with(no_args).and_return(:text)
+    allow(@column_foo).to receive(:text?).with(no_args).and_return(true)
+    allow(@column_foo).to receive(:null).with(no_args).and_return(true)
+    allow(@column_foo).to receive(:sql_type).with(no_args).and_return('clob')
 
     @column_bar = double("column_bar")
-    allow(@column_bar).to receive(:name).with().and_return(:bar)
-    allow(@column_bar).to receive(:type).with().and_return(:binary)
-    allow(@column_bar).to receive(:text?).with().and_return(false)
-    allow(@column_bar).to receive(:null).with().and_return(true)
-    allow(@column_bar).to receive(:sql_type).with().and_return('blob')
+    allow(@column_bar).to receive(:name).with(no_args).and_return(:bar)
+    allow(@column_bar).to receive(:type).with(no_args).and_return(:binary)
+    allow(@column_bar).to receive(:text?).with(no_args).and_return(false)
+    allow(@column_bar).to receive(:null).with(no_args).and_return(true)
+    allow(@column_bar).to receive(:sql_type).with(no_args).and_return('blob')
 
     @column_baz = double("column_baz")
-    allow(@column_baz).to receive(:name).with().and_return(:baz)
-    allow(@column_baz).to receive(:type).with().and_return(:integer)
-    allow(@column_baz).to receive(:text?).with().and_return(false)
-    allow(@column_baz).to receive(:null).with().and_return(true)
-    allow(@column_baz).to receive(:sql_type).with().and_return('integer')
+    allow(@column_baz).to receive(:name).with(no_args).and_return(:baz)
+    allow(@column_baz).to receive(:type).with(no_args).and_return(:integer)
+    allow(@column_baz).to receive(:text?).with(no_args).and_return(false)
+    allow(@column_baz).to receive(:null).with(no_args).and_return(true)
+    allow(@column_baz).to receive(:sql_type).with(no_args).and_return('integer')
 
     @column_quux = double("column_quux")
-    allow(@column_quux).to receive(:name).with().and_return(:quux)
-    allow(@column_quux).to receive(:type).with().and_return(:string)
-    allow(@column_quux).to receive(:text?).with().and_return(true)
-    allow(@column_quux).to receive(:null).with().and_return(true)
-    allow(@column_quux).to receive(:sql_type).with().and_return('varchar')
+    allow(@column_quux).to receive(:name).with(no_args).and_return(:quux)
+    allow(@column_quux).to receive(:type).with(no_args).and_return(:string)
+    allow(@column_quux).to receive(:text?).with(no_args).and_return(true)
+    allow(@column_quux).to receive(:null).with(no_args).and_return(true)
+    allow(@column_quux).to receive(:sql_type).with(no_args).and_return('varchar')
 
     @column_ajson = double("column_ajson")
-    allow(@column_ajson).to receive(:name).with().and_return(:ajson)
-    allow(@column_ajson).to receive(:type).with().and_return(:json)
-    allow(@column_ajson).to receive(:text?).with().and_return(false)
-    allow(@column_ajson).to receive(:null).with().and_return(true)
-    allow(@column_ajson).to receive(:sql_type).with().and_return('json')
+    allow(@column_ajson).to receive(:name).with(no_args).and_return(:ajson)
+    allow(@column_ajson).to receive(:type).with(no_args).and_return(:json)
+    allow(@column_ajson).to receive(:text?).with(no_args).and_return(false)
+    allow(@column_ajson).to receive(:null).with(no_args).and_return(true)
+    allow(@column_ajson).to receive(:sql_type).with(no_args).and_return('json')
 
     columns = [ @column_foo, @column_bar, @column_baz, @column_quux, @column_ajson ]
-    allow(@model_class).to receive(:columns).with().and_return(columns)
+    allow(@model_class).to receive(:columns).with(no_args).and_return(columns)
 
     allow(@model_class).to receive(:const_defined?).and_return(false)
     allow(@model_class).to receive(:const_set)
@@ -98,7 +98,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
     end
 
     it "should require a model class that's an AR class" do
-      allow(@model_class).to receive(:has_any_flex_columns?).with().and_return(false)
+      allow(@model_class).to receive(:has_any_flex_columns?).with(no_args).and_return(false)
       lambda { @klass.setup!(@model_class, :foo) { } }.should raise_error(ArgumentError)
     end
 
@@ -114,13 +114,13 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
     end
 
     it "should work if the table doesn't exist" do
-      allow(@model_class).to receive(:table_exists?).with().and_return(false)
+      allow(@model_class).to receive(:table_exists?).with(no_args).and_return(false)
       allow(@model_class).to receive(:columns).and_raise(StandardError) # to make sure we don't touch this
       @klass.setup!(@model_class, :foo) { }
     end
 
     it "should work if the column doesn't exist" do
-      allow(@model_class).to receive(:table_exists?).with().and_return(true)
+      allow(@model_class).to receive(:table_exists?).with(no_args).and_return(true)
       allow(@model_class).to receive(:columns).and_return([ @column_bar, @column_baz, @column_quux, @column_ajson ])
 
       @klass.setup!(@model_class, :foo) { }
@@ -211,7 +211,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
 
   describe "reset_column_information" do
     it "should still generate a fake column if the table still doesn't exist" do
-      allow(@model_class).to receive(:table_exists?).with().and_return(false)
+      allow(@model_class).to receive(:table_exists?).with(no_args).and_return(false)
       @klass.setup!(@model_class, :bar) { }
       c = @klass.column
       c.name.should == :bar
@@ -226,16 +226,16 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
     end
 
     it "should pull a real column if the table does exist" do
-      allow(@column_bar).to receive(:null).with().and_return(false)
+      allow(@column_bar).to receive(:null).with(no_args).and_return(false)
 
-      allow(@model_class).to receive(:table_exists?).with().and_return(false)
+      allow(@model_class).to receive(:table_exists?).with(no_args).and_return(false)
       @klass.setup!(@model_class, :bar) { }
       c = @klass.column
       c.name.should == :bar
       c.type.should == :string
       c.null.should == true
 
-      allow(@model_class).to receive(:table_exists?).with().and_return(true)
+      allow(@model_class).to receive(:table_exists?).with(no_args).and_return(true)
       @klass.reset_column_information
       c = @klass.column
       c.name.should == :bar
@@ -250,7 +250,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
 
       data_source = double("data_source")
 
-      allow(instance_variable_get("@column_#{column_name}")).to receive(:limit).with().and_return(length_limit)
+      allow(instance_variable_get("@column_#{column_name}")).to receive(:limit).with(no_args).and_return(length_limit)
 
       resulting_options = { :storage_string => storage_string, :data_source => data_source }.merge(resulting_options)
 
@@ -316,7 +316,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
     end
 
     it "should pass through the nullability setting correctly" do
-      allow(@column_foo).to receive(:null).with().and_return(false)
+      allow(@column_foo).to receive(:null).with(no_args).and_return(false)
       expect_options_transform({ }, 123, {
         :unknown_fields => :preserve,
         :length_limit => 123,
@@ -420,7 +420,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
   describe "#all_field_names" do
     it "should delegate to the field set" do
       @klass.setup!(@model_class, :foo) { }
-      expect(@field_set).to receive(:all_field_names).once.with().and_return([ :a, :x, :z, :q ])
+      expect(@field_set).to receive(:all_field_names).once.with(no_args).and_return([ :a, :x, :z, :q ])
       @klass.all_field_names.should == [ :a, :x, :z, :q ]
     end
   end
@@ -431,10 +431,10 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
 
       dmm = double("dmm")
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexFieldsDynamicMethods).and_return(dmm)
-      expect(dmm).to receive(:remove_all_methods!).with().once
+      expect(dmm).to receive(:remove_all_methods!).with(no_args).once
 
       mc_dmm = double("mc_dmm")
-      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with().and_return(mc_dmm)
+      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with(no_args).and_return(mc_dmm)
       expect(@field_set).to receive(:add_delegated_methods!).once.with(dmm, mc_dmm, @model_class)
 
       @klass.sync_methods!
@@ -445,15 +445,15 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
 
       dmm = double("dmm")
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexFieldsDynamicMethods).and_return(dmm)
-      expect(dmm).to receive(:remove_all_methods!).with().once
+      expect(dmm).to receive(:remove_all_methods!).with(no_args).once
 
       mc_dmm = double("mc_dmm")
-      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with().and_return(mc_dmm)
+      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with(no_args).and_return(mc_dmm)
       expect(@field_set).to receive(:add_delegated_methods!).once.with(dmm, mc_dmm, @model_class)
 
       @klass.sync_methods!
 
-      expect(dmm).to receive(:remove_all_methods!).with().once
+      expect(dmm).to receive(:remove_all_methods!).with(no_args).once
       expect(@field_set).to receive(:add_delegated_methods!).once.with(dmm, mc_dmm, @model_class)
 
       @klass.sync_methods!
@@ -468,7 +468,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
 
       dmm = double("dmm")
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexFieldsDynamicMethods).and_return(dmm)
-      expect(dmm).to receive(:remove_all_methods!).with().once
+      expect(dmm).to receive(:remove_all_methods!).with(no_args).once
 
       mc_dmm = Class.new
       mc_dmm.class_eval do
@@ -477,7 +477,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         end
       end
 
-      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with().and_return(mc_dmm)
+      allow(@model_class).to receive(:_flex_column_dynamic_methods_module).with(no_args).and_return(mc_dmm)
       expect(@field_set).to receive(:add_delegated_methods!).once.with(dmm, mc_dmm, @model_class)
 
       allow(@model_class).to receive(:_flex_columns_safe_to_define_method?).with("cm1").and_return(true)
@@ -534,7 +534,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         model = double("model")
         fco = double("fco")
         allow(model).to receive(:_flex_column_object_for).with(:foo, false).and_return(fco)
-        allow(fco).to receive(:deserialized?).with().and_return(true)
+        allow(fco).to receive(:deserialized?).with(no_args).and_return(true)
         @klass.requires_serialization_on_save?(model).should be
       end
 
@@ -542,7 +542,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         model = double("model")
         fco = double("fco")
         allow(model).to receive(:_flex_column_object_for).with(:foo, false).and_return(fco)
-        allow(fco).to receive(:deserialized?).with().and_return(false)
+        allow(fco).to receive(:deserialized?).with(no_args).and_return(false)
         @klass.requires_serialization_on_save?(model).should_not be
       end
 
@@ -550,7 +550,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         model = double("model")
         fco = double("fco")
         allow(model).to receive(:_flex_column_object_for).with(:foo, false).and_return(nil)
-        allow(@column_foo).to receive(:null).with().and_return(true)
+        allow(@column_foo).to receive(:null).with(no_args).and_return(true)
         @klass.requires_serialization_on_save?(model).should_not be
       end
 
@@ -558,7 +558,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         model = double("model")
         fco = double("fco")
         allow(model).to receive(:_flex_column_object_for).with(:foo, false).and_return(nil)
-        allow(@column_foo).to receive(:null).with().and_return(false)
+        allow(@column_foo).to receive(:null).with(no_args).and_return(false)
         allow(model).to receive(:[]).with(:foo).and_return("some data")
         @klass.requires_serialization_on_save?(model).should_not be
       end
@@ -567,7 +567,7 @@ describe FlexColumns::Definition::FlexColumnContentsClass do
         model = double("model")
         fco = double("fco")
         allow(model).to receive(:_flex_column_object_for).with(:foo, false).and_return(nil)
-        allow(@column_foo).to receive(:null).with().and_return(false)
+        allow(@column_foo).to receive(:null).with(no_args).and_return(false)
         allow(model).to receive(:[]).with(:foo).and_return(nil)
         @klass.requires_serialization_on_save?(model).should be
       end

--- a/spec/flex_columns/unit/errors_spec.rb
+++ b/spec/flex_columns/unit/errors_spec.rb
@@ -15,7 +15,7 @@ describe FlexColumns::Errors do
 
   before :each do
     @data_source = double("data_source")
-    allow(@data_source).to receive(:describe_flex_column_data_source).with().and_return("dfcds")
+    allow(@data_source).to receive(:describe_flex_column_data_source).with(no_args).and_return("dfcds")
   end
 
   describe FlexColumns::Errors::FieldError do
@@ -48,7 +48,7 @@ describe FlexColumns::Errors do
 
     it "should take model_class, column_name, new_field_name, existing_field_name, and json_storage_name" do
       model_class = double("model_class")
-      allow(model_class).to receive(:name).with().and_return("mcname")
+      allow(model_class).to receive(:name).with(no_args).and_return("mcname")
 
       instance = FlexColumns::Errors::ConflictingJsonStorageNameError.new(model_class, :foo, :bar, :baz, :quux)
       instance.model_class.should be(model_class)
@@ -133,9 +133,9 @@ describe FlexColumns::Errors do
     it "should take data_source, raw_string, and source_exception" do
       source_exception = double("source_exception")
       source_exception_class = double("source_exception_class")
-      allow(source_exception_class).to receive(:name).with().and_return("secname")
-      allow(source_exception).to receive(:class).with().and_return(source_exception_class)
-      allow(source_exception).to receive(:to_s).with().and_return("seto_s")
+      allow(source_exception_class).to receive(:name).with(no_args).and_return("secname")
+      allow(source_exception).to receive(:class).with(no_args).and_return(source_exception_class)
+      allow(source_exception).to receive(:to_s).with(no_args).and_return("seto_s")
 
       instance = FlexColumns::Errors::InvalidCompressedDataInDatabaseError.new(@data_source, "a" * 1_000, source_exception)
       instance.data_source.should be(@data_source)
@@ -178,9 +178,9 @@ describe FlexColumns::Errors do
     it "should take data_source, raw_string, and source_exception" do
       source_exception = double("source_exception")
       source_exception_class = double("source_exception_class")
-      allow(source_exception_class).to receive(:name).with().and_return("secname")
-      allow(source_exception).to receive(:class).with().and_return(source_exception_class)
-      allow(source_exception).to receive(:message).with().and_return("semessage")
+      allow(source_exception_class).to receive(:name).with(no_args).and_return("secname")
+      allow(source_exception).to receive(:class).with(no_args).and_return(source_exception_class)
+      allow(source_exception).to receive(:message).with(no_args).and_return("semessage")
 
       instance = FlexColumns::Errors::UnparseableJsonInDatabaseError.new(@data_source, "a" * 1_000, source_exception)
       instance.data_source.should be(@data_source)
@@ -197,22 +197,22 @@ describe FlexColumns::Errors do
     it "should strip out characters that aren't of a valid encoding" do
       source_exception = double("source_exception")
       source_exception_class = double("source_exception_class")
-      allow(source_exception_class).to receive(:name).with().and_return("secname")
-      allow(source_exception).to receive(:class).with().and_return(source_exception_class)
+      allow(source_exception_class).to receive(:name).with(no_args).and_return("secname")
+      allow(source_exception).to receive(:class).with(no_args).and_return(source_exception_class)
 
       source_message = double("source_message")
       expect(source_message).to receive(:force_encoding).once.with("UTF-8")
       chars = [ double("char-a"), double("char-b"), double("char-c") ]
-      allow(chars[0]).to receive(:valid_encoding?).with().and_return(true)
-      allow(chars[0]).to receive(:to_s).with().and_return("X")
-      allow(chars[0]).to receive(:inspect).with().and_return("X")
-      allow(chars[1]).to receive(:valid_encoding?).with().and_return(false)
-      allow(chars[2]).to receive(:valid_encoding?).with().and_return(true)
-      allow(chars[2]).to receive(:to_s).with().and_return("Z")
-      allow(chars[2]).to receive(:inspect).with().and_return("Z")
-      allow(source_message).to receive(:chars).with().and_return(chars)
+      allow(chars[0]).to receive(:valid_encoding?).with(no_args).and_return(true)
+      allow(chars[0]).to receive(:to_s).with(no_args).and_return("X")
+      allow(chars[0]).to receive(:inspect).with(no_args).and_return("X")
+      allow(chars[1]).to receive(:valid_encoding?).with(no_args).and_return(false)
+      allow(chars[2]).to receive(:valid_encoding?).with(no_args).and_return(true)
+      allow(chars[2]).to receive(:to_s).with(no_args).and_return("Z")
+      allow(chars[2]).to receive(:inspect).with(no_args).and_return("Z")
+      allow(source_message).to receive(:chars).with(no_args).and_return(chars)
 
-      allow(source_exception).to receive(:message).with().and_return(source_message)
+      allow(source_exception).to receive(:message).with(no_args).and_return(source_message)
 
       instance = FlexColumns::Errors::UnparseableJsonInDatabaseError.new(@data_source, "a" * 1_000, source_exception)
       instance.data_source.should be(@data_source)
@@ -236,22 +236,22 @@ describe FlexColumns::Errors do
       chars = [ ]
       200.times { |i| chars << double("char-#{i}") }
       chars.each_with_index do |char, i|
-        allow(char).to receive(:valid_encoding?).with().and_return(true)
-        allow(char).to receive(:to_s).with().and_return((65 + (i % 26)).chr)
-        allow(char).to receive(:inspect).with().and_return((65 + (i % 26)).chr)
+        allow(char).to receive(:valid_encoding?).with(no_args).and_return(true)
+        allow(char).to receive(:to_s).with(no_args).and_return((65 + (i % 26)).chr)
+        allow(char).to receive(:inspect).with(no_args).and_return((65 + (i % 26)).chr)
       end
 
       [ 53, 68, 95 ].each do |bad_char_pos|
-        allow(chars[bad_char_pos]).to receive(:valid_encoding?).with().and_return(false)
+        allow(chars[bad_char_pos]).to receive(:valid_encoding?).with(no_args).and_return(false)
         allow(chars[bad_char_pos]).to receive(:unpack).with("H*").and_return("UPC#{bad_char_pos}")
       end
 
-      allow(chars[53]).to receive(:valid_encoding?).with().and_return(false)
-      allow(chars[68]).to receive(:valid_encoding?).with().and_return(false)
-      allow(chars[95]).to receive(:valid_encoding?).with().and_return(false)
+      allow(chars[53]).to receive(:valid_encoding?).with(no_args).and_return(false)
+      allow(chars[68]).to receive(:valid_encoding?).with(no_args).and_return(false)
+      allow(chars[95]).to receive(:valid_encoding?).with(no_args).and_return(false)
 
       raw_string = double("raw_string")
-      allow(raw_string).to receive(:chars).with().and_return(chars)
+      allow(raw_string).to receive(:chars).with(no_args).and_return(chars)
 
       instance = FlexColumns::Errors::IncorrectlyEncodedStringInDatabaseError.new(@data_source, raw_string)
 

--- a/spec/flex_columns/unit/has_flex_columns_spec.rb
+++ b/spec/flex_columns/unit/has_flex_columns_spec.rb
@@ -72,8 +72,8 @@ describe FlexColumns::HasFlexColumns do
       expect(Class).to receive(:new).once.ordered.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc1)
       expect(fcc1).to receive(:setup!).once.ordered.with(@klass, :foo, { })
 
-      expect(dmm).to receive(:remove_all_methods!).once.ordered.with()
-      expect(fcc1).to receive(:sync_methods!).once.ordered.with()
+      expect(dmm).to receive(:remove_all_methods!).once.ordered.with(no_args)
+      expect(fcc1).to receive(:sync_methods!).once.ordered.with(no_args)
 
       @klass.flex_column(:foo)
 
@@ -81,16 +81,16 @@ describe FlexColumns::HasFlexColumns do
       expect(Class).to receive(:new).once.ordered.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc2)
       expect(fcc2).to receive(:setup!).once.ordered.with(@klass, :bar, { })
 
-      expect(dmm).to receive(:remove_all_methods!).once.ordered.with()
-      expect(fcc1).to receive(:sync_methods!).once.ordered.with()
-      expect(fcc2).to receive(:sync_methods!).once.ordered.with()
+      expect(dmm).to receive(:remove_all_methods!).once.ordered.with(no_args)
+      expect(fcc1).to receive(:sync_methods!).once.ordered.with(no_args)
+      expect(fcc2).to receive(:sync_methods!).once.ordered.with(no_args)
 
       @klass.flex_column(:bar)
 
 
-      expect(dmm).to receive(:remove_all_methods!).once.ordered.with()
-      expect(fcc1).to receive(:sync_methods!).once.ordered.with()
-      expect(fcc2).to receive(:sync_methods!).once.ordered.with()
+      expect(dmm).to receive(:remove_all_methods!).once.ordered.with(no_args)
+      expect(fcc1).to receive(:sync_methods!).once.ordered.with(no_args)
+      expect(fcc2).to receive(:sync_methods!).once.ordered.with(no_args)
 
       @klass._flex_columns_redefine_all_methods!
     end
@@ -98,7 +98,7 @@ describe FlexColumns::HasFlexColumns do
 
   describe "#flex_column" do
     it "should do nothing if the table doesn't exist" do
-      allow(@klass).to receive(:table_exists?).with().and_return(false)
+      allow(@klass).to receive(:table_exists?).with(no_args).and_return(false)
       @klass.flex_column('foo')
     end
 
@@ -106,7 +106,7 @@ describe FlexColumns::HasFlexColumns do
       fcc = double("fcc")
       expect(Class).to receive(:new).once.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc)
       expect(fcc).to receive(:setup!).once.with(@klass, :foo, { })
-      allow(fcc).to receive(:sync_methods!).with()
+      allow(fcc).to receive(:sync_methods!).with(no_args)
 
       @klass.flex_column(' fOo ')
     end
@@ -120,13 +120,13 @@ describe FlexColumns::HasFlexColumns do
       expect(fcc_foo).to receive(:setup!).once.with(@klass, :foo, { }) do |*args, &block|
         passed_block = block
       end
-      allow(fcc_foo).to receive(:column_name).with().and_return(:foo)
+      allow(fcc_foo).to receive(:column_name).with(no_args).and_return(:foo)
 
       dmm = double("dmm")
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexColumnsDynamicMethods).and_return(dmm)
 
-      expect(dmm).to receive(:remove_all_methods!).once.with()
-      expect(fcc_foo).to receive(:sync_methods!).once.with()
+      expect(dmm).to receive(:remove_all_methods!).once.with(no_args)
+      expect(fcc_foo).to receive(:sync_methods!).once.with(no_args)
       @klass.flex_column(:foo) do
         quux(:a, :z, :q)
       end
@@ -144,11 +144,11 @@ describe FlexColumns::HasFlexColumns do
       fcc_bar = double("fcc_bar")
       expect(Class).to receive(:new).once.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc_bar)
       expect(fcc_bar).to receive(:setup!).once.with(@klass, :bar, { })
-      allow(fcc_bar).to receive(:column_name).with().and_return(:bar)
+      allow(fcc_bar).to receive(:column_name).with(no_args).and_return(:bar)
 
-      expect(dmm).to receive(:remove_all_methods!).once.with()
-      expect(fcc_foo).to receive(:sync_methods!).once.with()
-      expect(fcc_bar).to receive(:sync_methods!).once.with()
+      expect(dmm).to receive(:remove_all_methods!).once.with(no_args)
+      expect(fcc_foo).to receive(:sync_methods!).once.with(no_args)
+      expect(fcc_bar).to receive(:sync_methods!).once.with(no_args)
       @klass.flex_column(:bar)
 
       @klass._flex_column_class_for(:foo).should be(fcc_foo)
@@ -163,11 +163,11 @@ describe FlexColumns::HasFlexColumns do
       fcc_foo_2 = double("fcc_foo_2")
       expect(Class).to receive(:new).once.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc_foo_2)
       expect(fcc_foo_2).to receive(:setup!).once.with(@klass, :foo, { :a => :b, :c => :d })
-      allow(fcc_foo_2).to receive(:column_name).with().and_return(:foo)
+      allow(fcc_foo_2).to receive(:column_name).with(no_args).and_return(:foo)
 
-      expect(dmm).to receive(:remove_all_methods!).once.with()
-      expect(fcc_foo_2).to receive(:sync_methods!).once.with()
-      expect(fcc_bar).to receive(:sync_methods!).once.with()
+      expect(dmm).to receive(:remove_all_methods!).once.with(no_args)
+      expect(fcc_foo_2).to receive(:sync_methods!).once.with(no_args)
+      expect(fcc_bar).to receive(:sync_methods!).once.with(no_args)
 
       @klass.flex_column(:foo, :a => :b, :c => :d)
 
@@ -193,11 +193,11 @@ describe FlexColumns::HasFlexColumns do
       expect(@fcc_foo).to receive(:setup!).once.with(@klass, :foo, { :aaa => :bbb, :ccc => :ddd })
       expect(@fcc_foo).to receive(:sync_methods!).once
 
-      allow(@fcc_foo).to receive(:column_name).with().and_return(:foo)
+      allow(@fcc_foo).to receive(:column_name).with(no_args).and_return(:foo)
 
       @dmm = double("dmm")
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexColumnsDynamicMethods).and_return(@dmm)
-      expect(@dmm).to receive(:remove_all_methods!).once.with()
+      expect(@dmm).to receive(:remove_all_methods!).once.with(no_args)
 
       @klass.flex_column(:foo, :aaa => :bbb, :ccc => :ddd)
 
@@ -206,9 +206,9 @@ describe FlexColumns::HasFlexColumns do
       expect(@fcc_bar).to receive(:setup!).once.with(@klass, :bar, { })
       expect(@fcc_bar).to receive(:sync_methods!).once
 
-      allow(@fcc_bar).to receive(:column_name).with().and_return(:bar)
+      allow(@fcc_bar).to receive(:column_name).with(no_args).and_return(:bar)
 
-      expect(@dmm).to receive(:remove_all_methods!).once.with()
+      expect(@dmm).to receive(:remove_all_methods!).once.with(no_args)
       expect(@fcc_foo).to receive(:sync_methods!).once
       @klass.flex_column(:bar)
     end
@@ -226,7 +226,7 @@ describe FlexColumns::HasFlexColumns do
         fcc_foo_instance = double("fcc_foo_instance")
         expect(@fcc_foo).to receive(:new).once.with(instance).and_return(fcc_foo_instance)
         hash_for_serialization = double("hash_for_serialization")
-        expect(fcc_foo_instance).to receive(:to_hash_for_serialization).once.with().and_return(hash_for_serialization)
+        expect(fcc_foo_instance).to receive(:to_hash_for_serialization).once.with(no_args).and_return(hash_for_serialization)
 
         instance.read_attribute_for_serialization('foo').should be(hash_for_serialization)
         instance.read_attribute_for_serialization('baz').should == "rafs_baz_rafs"
@@ -246,13 +246,13 @@ describe FlexColumns::HasFlexColumns do
 
         fcc_foo_instance = double("fcc_foo_instance")
         expect(@fcc_foo).to receive(:new).once.with(instance).and_return(fcc_foo_instance)
-        expect(fcc_foo_instance).to receive(:to_hash_for_serialization).once.with().and_return({ :aaa => 111, :bbb => 222 })
+        expect(fcc_foo_instance).to receive(:to_hash_for_serialization).once.with(no_args).and_return({ :aaa => 111, :bbb => 222 })
 
         fcc_bar_instance = double("fcc_bar_instance")
         expect(@fcc_bar).to receive(:new).once.with(instance).and_return(fcc_bar_instance)
-        expect(fcc_bar_instance).to receive(:to_hash_for_serialization).once.with().and_return({ :aaa => 234, :ccc => 'xxx' })
+        expect(fcc_bar_instance).to receive(:to_hash_for_serialization).once.with(no_args).and_return({ :aaa => 234, :ccc => 'xxx' })
 
-        allow(instance).to receive(:include_root_in_json).with().and_return(false)
+        allow(instance).to receive(:include_root_in_json).with(no_args).and_return(false)
 
         instance.as_json.should == { :z => 123, :bbb => 456,
           :foo => { :aaa => 111, :bbb => 222 },
@@ -276,26 +276,26 @@ describe FlexColumns::HasFlexColumns do
       fcc_foo_instance = double("fcc_foo_instance")
       expect(@fcc_foo).to receive(:new).once.with(instance).and_return(fcc_foo_instance)
       instance._flex_column_owned_object_for(:foo).should be(fcc_foo_instance)
-      allow(fcc_foo_instance).to receive(:deserialized?).with().and_return(false)
+      allow(fcc_foo_instance).to receive(:deserialized?).with(no_args).and_return(false)
 
-      expect(fcc_foo_instance).to receive(:before_validation!).once.with()
+      expect(fcc_foo_instance).to receive(:before_validation!).once.with(no_args)
       instance._flex_columns_before_validation!
 
 
       fcc_bar_instance = double("fcc_bar_instance")
       expect(@fcc_bar).to receive(:new).once.with(instance).and_return(fcc_bar_instance)
       instance._flex_column_owned_object_for(:bar).should be(fcc_bar_instance)
-      allow(fcc_bar_instance).to receive(:deserialized?).with().and_return(true)
+      allow(fcc_bar_instance).to receive(:deserialized?).with(no_args).and_return(true)
 
-      expect(fcc_foo_instance).to receive(:before_validation!).once.with()
-      expect(fcc_bar_instance).to receive(:before_validation!).once.with()
+      expect(fcc_foo_instance).to receive(:before_validation!).once.with(no_args)
+      expect(fcc_bar_instance).to receive(:before_validation!).once.with(no_args)
       instance._flex_columns_before_validation!
 
-      allow(fcc_foo_instance).to receive(:deserialized?).with().and_return(true)
-      allow(fcc_bar_instance).to receive(:deserialized?).with().and_return(true)
+      allow(fcc_foo_instance).to receive(:deserialized?).with(no_args).and_return(true)
+      allow(fcc_bar_instance).to receive(:deserialized?).with(no_args).and_return(true)
 
-      expect(fcc_foo_instance).to receive(:before_validation!).once.with()
-      expect(fcc_bar_instance).to receive(:before_validation!).once.with()
+      expect(fcc_foo_instance).to receive(:before_validation!).once.with(no_args)
+      expect(fcc_bar_instance).to receive(:before_validation!).once.with(no_args)
       instance._flex_columns_before_validation!
     end
 
@@ -318,14 +318,14 @@ describe FlexColumns::HasFlexColumns do
       instance._flex_column_owned_object_for(:bar).should be(fcc_bar_instance)
       allow(@fcc_bar).to receive(:requires_serialization_on_save?).with(instance).and_return(true)
 
-      expect(fcc_bar_instance).to receive(:before_save!).once.with()
+      expect(fcc_bar_instance).to receive(:before_save!).once.with(no_args)
       instance._flex_columns_before_save!
 
       allow(@fcc_foo).to receive(:requires_serialization_on_save?).with(instance).and_return(true)
       allow(@fcc_bar).to receive(:requires_serialization_on_save?).with(instance).and_return(true)
 
-      expect(fcc_foo_instance).to receive(:before_save!).once.with()
-      expect(fcc_bar_instance).to receive(:before_save!).once.with()
+      expect(fcc_foo_instance).to receive(:before_save!).once.with(no_args)
+      expect(fcc_bar_instance).to receive(:before_save!).once.with(no_args)
       instance._flex_columns_before_save!
     end
 
@@ -354,9 +354,9 @@ describe FlexColumns::HasFlexColumns do
       expect(Class).to receive(:new).once.with(FlexColumns::Contents::FlexColumnContentsBase).and_return(fcc_conflicting)
       expect(fcc_conflicting).to receive(:setup!).once.with(@klass, :foo, { })
       expect(fcc_conflicting).to receive(:sync_methods!).once
-      allow(fcc_conflicting).to receive(:column_name).with().and_return(:foo)
+      allow(fcc_conflicting).to receive(:column_name).with(no_args).and_return(:foo)
 
-      expect(@dmm).to receive(:remove_all_methods!).once.with()
+      expect(@dmm).to receive(:remove_all_methods!).once.with(no_args)
 
       expect(@fcc_bar).to receive(:sync_methods!).once
       @klass.flex_column(:foo)

--- a/spec/flex_columns/unit/including/include_flex_columns_spec.rb
+++ b/spec/flex_columns/unit/including/include_flex_columns_spec.rb
@@ -8,7 +8,7 @@ describe FlexColumns::Including::IncludeFlexColumns do
   describe "#_flex_column_included_object_for" do
     it "should raise an error if there is no appropriate association" do
       allow(@klass).to receive(:_flex_column_is_included_from).with(:foo).and_return(nil)
-      allow(@klass).to receive(:name).with().and_return("klassname")
+      allow(@klass).to receive(:name).with(no_args).and_return("klassname")
       instance = @klass.new
 
       lambda { instance._flex_column_included_object_for(:foo) }.should raise_error(FlexColumns::Errors::NoSuchColumnError, /klassname.*foo/i)
@@ -19,7 +19,7 @@ describe FlexColumns::Including::IncludeFlexColumns do
       instance = @klass.new
 
       association_object = double("association_object")
-      allow(instance).to receive(:assocname).with().and_return(association_object)
+      allow(instance).to receive(:assocname).with(no_args).and_return(association_object)
       allow(association_object).to receive(:colname).and_return(:baz)
 
       instance._flex_column_included_object_for(:colname).should == :baz
@@ -30,8 +30,8 @@ describe FlexColumns::Including::IncludeFlexColumns do
       instance = @klass.new
 
       association_object = double("association_object")
-      allow(instance).to receive(:assocname).with().and_return(nil)
-      allow(instance).to receive(:build_assocname).with().and_return(association_object)
+      allow(instance).to receive(:assocname).with(no_args).and_return(nil)
+      allow(instance).to receive(:build_assocname).with(no_args).and_return(association_object)
       allow(association_object).to receive(:colname).and_return(:baz)
 
       instance._flex_column_included_object_for(:colname).should == :baz
@@ -48,16 +48,16 @@ describe FlexColumns::Including::IncludeFlexColumns do
   describe "#include_flex_columns_from" do
     before :each do
       @assoc1 = double("assoc1")
-      allow(@assoc1).to receive(:name).with().and_return(:assoc1)
-      allow(@assoc1).to receive(:macro).with().and_return(:has_one)
+      allow(@assoc1).to receive(:name).with(no_args).and_return(:assoc1)
+      allow(@assoc1).to receive(:macro).with(no_args).and_return(:has_one)
       @assoc2 = double("assoc2")
-      allow(@assoc2).to receive(:name).with().and_return(:assoc2)
-      allow(@assoc2).to receive(:macro).with().and_return(:belongs_to)
+      allow(@assoc2).to receive(:name).with(no_args).and_return(:assoc2)
+      allow(@assoc2).to receive(:macro).with(no_args).and_return(:belongs_to)
 
       allow(@klass).to receive(:reflect_on_association).with(:assoc1).and_return(@assoc1)
       allow(@klass).to receive(:reflect_on_association).with(:assoc2).and_return(@assoc2)
 
-      allow(@klass).to receive(:reflect_on_all_associations).with().and_return([ @assoc1, @assoc2 ])
+      allow(@klass).to receive(:reflect_on_all_associations).with(no_args).and_return([ @assoc1, @assoc2 ])
     end
 
     it "should validate its options properly" do
@@ -73,14 +73,14 @@ describe FlexColumns::Including::IncludeFlexColumns do
     end
 
     it "should raise if the association is of the wrong type" do
-      allow(@assoc1).to receive(:macro).with().and_return(:has_many)
+      allow(@assoc1).to receive(:macro).with(no_args).and_return(:has_many)
       lambda { @klass.include_flex_columns_from(:assoc1) }.should raise_error(ArgumentError, /assoc1.*has_many/mi)
     end
 
     it "should raise if the target class does not respond to #has_any_flex_columns?" do
       association_class = double("association_class")
-      allow(association_class).to receive(:name).with().and_return("acname")
-      allow(@assoc2).to receive(:klass).with().and_return(association_class)
+      allow(association_class).to receive(:name).with(no_args).and_return("acname")
+      allow(@assoc2).to receive(:klass).with(no_args).and_return(association_class)
       allow(association_class).to receive(:respond_to?).with(:has_any_flex_columns?).and_return(false)
 
       lambda { @klass.include_flex_columns_from(:assoc2) }.should raise_error(ArgumentError, /assoc2.*acname/mi)
@@ -88,9 +88,9 @@ describe FlexColumns::Including::IncludeFlexColumns do
 
     it "should raise if the target class returns false from #has_any_flex_columns?" do
       association_class = double("association_class")
-      allow(association_class).to receive(:name).with().and_return("acname")
-      allow(@assoc2).to receive(:klass).with().and_return(association_class)
-      allow(association_class).to receive(:has_any_flex_columns?).with().and_return(false)
+      allow(association_class).to receive(:name).with(no_args).and_return("acname")
+      allow(@assoc2).to receive(:klass).with(no_args).and_return(association_class)
+      allow(association_class).to receive(:has_any_flex_columns?).with(no_args).and_return(false)
 
       lambda { @klass.include_flex_columns_from(:assoc2) }.should raise_error(ArgumentError, /assoc2.*acname/mi)
     end
@@ -100,9 +100,9 @@ describe FlexColumns::Including::IncludeFlexColumns do
       expect(FlexColumns::Util::DynamicMethodsModule).to receive(:new).once.with(@klass, :FlexColumnsIncludedColumnsMethods).and_return(dmm)
 
       ac1 = double("ac1")
-      allow(@assoc1).to receive(:klass).with().and_return(ac1)
-      allow(ac1).to receive(:has_any_flex_columns?).with().and_return(true)
-      allow(ac1).to receive(:_all_flex_column_names).with().and_return([ :ac1fc1, :ac1fc2 ])
+      allow(@assoc1).to receive(:klass).with(no_args).and_return(ac1)
+      allow(ac1).to receive(:has_any_flex_columns?).with(no_args).and_return(true)
+      allow(ac1).to receive(:_all_flex_column_names).with(no_args).and_return([ :ac1fc1, :ac1fc2 ])
 
       ac1fc1_fcc = double("ac1fc1_fcc")
       expect(ac1fc1_fcc).to receive(:include_fields_into).once.ordered.with(dmm, :assoc1, @klass, :prefix => 'abz', :delegate => false, :visibility => :private)
@@ -112,9 +112,9 @@ describe FlexColumns::Including::IncludeFlexColumns do
       allow(ac1).to receive(:_flex_column_class_for).with(:ac1fc2).and_return(ac1fc2_fcc)
 
       ac2 = double("ac2")
-      allow(@assoc2).to receive(:klass).with().and_return(ac2)
-      allow(ac2).to receive(:has_any_flex_columns?).with().and_return(true)
-      allow(ac2).to receive(:_all_flex_column_names).with().and_return([ :ac2fc1, :ac2fc2 ])
+      allow(@assoc2).to receive(:klass).with(no_args).and_return(ac2)
+      allow(ac2).to receive(:has_any_flex_columns?).with(no_args).and_return(true)
+      allow(ac2).to receive(:_all_flex_column_names).with(no_args).and_return([ :ac2fc1, :ac2fc2 ])
 
       ac2fc1_fcc = double("ac2fc1_fcc")
       expect(ac2fc1_fcc).to receive(:include_fields_into).once.ordered.with(dmm, :assoc2, @klass, :prefix => 'abz', :delegate => false, :visibility => :private)


### PR DESCRIPTION
## https://github.com/elastic/search-developer-productivity/issues/2642

### Description
In order to proceed with the Rails 6 upgrade, it's required to bump `activerecord` maximum version to 7.

This PR is dedicated to bumping `activerecord`