### PR TITLE
Allow Rails 7.x (ActiveSupport < 8)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `flex_columns` Changelog
 
+## 1.0.12
+
+* Relax ActiveRecord/ActiveSupport constraints to allow Rails 7.x (`< 8`)
+
 ## 1.0.10, 2022-04-11
 
 * Bump ActiveRecord version to be compatible with Rails 6

--- a/flex_columns.gemspec
+++ b/flex_columns.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   ar_version = ar_version.strip if ar_version
 
   version_spec = case ar_version
-  when nil then [ ">= 3.0", "< 7" ]
+  when nil then [ ">= 3.0", "< 8" ]
   when 'master' then nil
   else [ "=#{ar_version}" ]
   end
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
     s.add_dependency("activerecord", *version_spec)
   end
 
-  s.add_dependency "activesupport", ">= 3.0", "< 7"
+  s.add_dependency "activesupport", ">= 3.0", "< 8"
 
   # i18n released an 0.7.0 that's incompatible with Ruby 1.8.
   if RUBY_VERSION =~ /^1\.8\./

--- a/lib/flex_columns/version.rb
+++ b/lib/flex_columns/version.rb
@@ -1,4 +1,4 @@
 module FlexColumns
   # The current version of FlexColumns.
-  VERSION = "1.0.11"
+  VERSION = "1.0.12"
 end


### PR DESCRIPTION
## Summary
- Relax `activerecord`/`activesupport` gemspec constraints from `< 7` to `< 8`
- Release version **1.0.12** for the Swiftype website Rails 7.2 upgrade

## Test plan
- [x] CI green on this branch
- [x] Website `bundle update flex_columns` resolves against Rails 7.2


Made with [Cursor](https://cursor.com)